### PR TITLE
Mark preloaded SVGs with attribute `as='image'`

### DIFF
--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -428,7 +428,7 @@ class autoptimizeExtra
                 if ( ' type="font/eot"' === $mime_type ) {
                     $mime_type = 'application/vnd.ms-fontobject';
                 }
-            } elseif ( autoptimizeUtils::str_ends_in( $_preload, '.jpeg' ) || autoptimizeUtils::str_ends_in( $_preload, '.jpg' ) || autoptimizeUtils::str_ends_in( $_preload, '.webp' ) || autoptimizeUtils::str_ends_in( $_preload, '.png' ) || autoptimizeUtils::str_ends_in( $_preload, '.gif' ) ) {
+            } elseif ( autoptimizeUtils::str_ends_in( $_preload, '.jpeg' ) || autoptimizeUtils::str_ends_in( $_preload, '.jpg' ) || autoptimizeUtils::str_ends_in( $_preload, '.webp' ) || autoptimizeUtils::str_ends_in( $_preload, '.png' ) || autoptimizeUtils::str_ends_in( $_preload, '.gif' ) || autoptimizeUtils::str_ends_in( $_preload, '.svg' ) ) {
                 $preload_as = 'image';
             } else {
                 $preload_as = 'other';


### PR DESCRIPTION
As per the W3C spec, SVGs should be marked as 'image': https://w3c.github.io/preload/#as-attribute

Fixes #360